### PR TITLE
フォロー済み案件編集時にタスク担当者が削除されるバグ修正

### DIFF
--- a/src/Template/Element/checkboxForm.ctp
+++ b/src/Template/Element/checkboxForm.ctp
@@ -13,6 +13,7 @@
                         'templates' => [
                             'inputContainer' => '{{content}}',
                         ],
+                        'disabled' => $disabled,
                     ]);
                 ?>
             </div>

--- a/src/Template/Items/edit.ctp
+++ b/src/Template/Items/edit.ctp
@@ -76,18 +76,15 @@
             'disabled' => $item->is_followed,
             'value'=>$default_overed_at,
             ]) ?>
-        <?php
-            if (!$item->is_followed) {
-                echo $this->element('checkboxForm', [
-                    'name' => 'projects_users._ids',
-                    'label' => '担当者 : ',
-                    'classes' => 'add-item',
-                    'form' => $this->Form,
-                    'options' => $users_array,
-                    'default' => $checked_users_array,
-                ]);
-            }
-        ?>
+        <?= $this->element('checkboxForm', [
+            'name' => 'projects_users._ids',
+            'label' => '担当者 : ',
+            'classes' => 'add-item',
+            'form' => $this->Form,
+            'options' => $users_array,
+            'default' => $checked_users_array,
+            'disabled' => $item->is_followed,
+            ]) ?>
     </div>
 </fieldset>
 <div class="form-container-footer">


### PR DESCRIPTION
## 背景

- フォロー済み案件を編集すると、エラー画面に遷移し、タスク担当者が削除された状態で案件が更新されてしまっていた
- フォロー済み案件の編集画面では、フォロー前と異なり、タスク担当者を編集できるチェックボックスが表示されないようになっている
  - したがって、フォロー済み案件の編集画面から更新を行うと、タスク担当者の情報がサーバに送信されない
  - しかし、サーバ側は、フロントエンド側からタスク担当者の情報が送信されることを想定している
  - すると、サーバ側は、タスク担当者の情報を受け取れないため、タスク担当者の情報をなしにして案件を更新してしまう

## この PR で解決すべき課題

- フロントエンド側からサーバ側に、フォロー済み案件の編集時にもタスク担当者の情報を送信する必要がある
- しかし、フォロー済み案件の編集画面では、タスク担当者を編集できるべきではない

## この PR での変更点

- フォロー済み案件の編集画面に、タスク担当者の編集項目を表示した
- フォロー済みの場合のみ、タスク担当者のチェックボックスを選択できないようにした

##  TODO

- [x] 動作検証
  - お願いします 🙇 